### PR TITLE
Hotfix for a VRAM leak in texture_refine.py - ambiguous float to double casting in windows found

### DIFF
--- a/instant-nsr-pl/texture_refine.py
+++ b/instant-nsr-pl/texture_refine.py
@@ -22,7 +22,7 @@ from icecream import ic
 steps = 200
 lr_clr = 2e-3
 scale = 1
-bg_color = np.array([1,1,1])
+bg_color = np.array([1,1,1], dtype=np.float32) #to prevent automatic float64 typecasting by numpy, ironing out the ambiguous declaration
 cam_path = './datasets/fixed_poses'
 views = ['front', 'front_right', 'right', 'back', 'left', 'front_left']
 view_nums = len(views)


### PR DESCRIPTION
There seems to be a VRAM leak caused by an ambiguous declaration in the BG color global var, which leads to an input image cast to float64 from float32, hence almost doubling the VRAM usage. Consider reviewing the codes to see if there are any more memory leaks. I didn't test this on the linux so don't know for sure if this is an issue in any os other than the windows x64.